### PR TITLE
show current courses on academics page

### DIFF
--- a/src/features/Courses.tsx
+++ b/src/features/Courses.tsx
@@ -35,12 +35,7 @@ const Courses = () => {
   useEffect(() => {
     let isMounted = true;
     getCourseSchedule()
-      .then(res => {
-        const currentCourses = res.filter(c =>
-          c.attributes.meetingTimes.find(t => t.beginDate && Date.parse(t.beginDate) <= Date.now())
-        );
-        isMounted && setCourses(currentCourses);
-      })
+      .then(res => isMounted && setCourses(res))
       .catch(console.log);
 
     return () => {


### PR DESCRIPTION
fixes a bug that I introduced in filtering out the "current courses".. Academics page should show all current courses even though they haven't yet started the term.