### PR TITLE
updates empty state for planner-items card

### DIFF
--- a/src/features/PlannerItems.tsx
+++ b/src/features/PlannerItems.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import styled from 'styled-components';
 import Skeleton from 'react-loading-skeleton';
 import { format } from 'date-fns';
 import { faFileEdit } from '@fortawesome/pro-light-svg-icons';
@@ -14,11 +15,29 @@ import {
 } from '../ui/List';
 import { usePlannerItems } from '../api/student/planner-items';
 import { AuthorizeCanvas } from '../features/canvas/AuthorizeCanvas';
-import { Color } from '../theme';
+import { theme, Color } from '../theme';
 import Url from '../util/externalUrls.data';
 import { ExternalLink } from '../ui/Link';
 import { UserContext } from '../App';
 import { Event } from '../util/gaTracking';
+import assignment from '../assets/assignment.svg';
+
+const NoItems = styled.div`
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: column;
+  align-items: center;
+  padding: ${theme.spacing.unit * 4}px ${theme.spacing.unit * 8}px 0px ${theme.spacing.unit * 8}px;
+`;
+
+const NoItemsImage = styled.img`
+  height: 60px;
+`;
+
+const NoItemsText = styled.p`
+  color: ${Color['neutral-550']};
+  text-align: center;
+`;
 
 /**
  * Upcoming Assignments Card
@@ -63,7 +82,12 @@ const PlannerItems = () => {
         </List>
       );
     } else if (user.isCanvasOptIn === true) {
-      return <EmptyState />;
+      return (
+        <NoItems>
+          <NoItemsImage src={assignment} alt="" />
+          <NoItemsText>You have no upcoming Canvas assignments</NoItemsText>
+        </NoItems>
+      );
     }
   };
 
@@ -88,10 +112,5 @@ const PlannerItems = () => {
     </Card>
   );
 };
-
-// <ListItemContent as="a" href={url} target="_blank">
-
-// Todo: Replace with actual empty state when ready in mockups.
-const EmptyState = () => <span>NO ASSIGNMENTS</span>;
 
 export default PlannerItems;

--- a/src/features/__tests__/PlannerItems.test.tsx
+++ b/src/features/__tests__/PlannerItems.test.tsx
@@ -37,10 +37,12 @@ describe('<PlannerItems />', () => {
     expect(mockGAEvent).toHaveBeenCalled();
   });
 
-  it('should find "NO ASSIGNMENTS" if our promise returns empty', async () => {
+  it('should find empty state if our promise returns empty', async () => {
     mockUsePlannerItems.mockReturnValue(mockNoData);
     const { getByText } = render(<PlannerItems />);
-    const element = await waitForElement(() => getByText('NO ASSIGNMENTS'));
+    const element = await waitForElement(() =>
+      getByText('You have no upcoming Canvas assignments')
+    );
     expect(element).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
fixes the empty state for planner items in the academics page

![Screenshot from 2019-10-18 11-10-41](https://user-images.githubusercontent.com/32885/67117609-fb4d1780-f197-11e9-84dd-c4b92b735f25.png)
