### PR TITLE
uses canvas plannable_date as item date

### DIFF
--- a/src/api/student/__mocks__/plannerItems.data.ts
+++ b/src/api/student/__mocks__/plannerItems.data.ts
@@ -16,7 +16,7 @@ export default {
         needs_grading: false,
         has_feedback: false
       },
-      plannable_date: '2019-05-02T06:59:00Z',
+      plannable_date: new Date(),
       plannable: {
         id: 8514159,
         title: 'Testo Planner Discussion',
@@ -48,7 +48,7 @@ export default {
         needs_grading: false,
         has_feedback: false
       },
-      plannable_date: '2019-05-02T06:59:00Z',
+      plannable_date: new Date(),
       plannable: {
         id: 234234,
         title: 'Planner Announcement Test',

--- a/src/features/PlannerItems.tsx
+++ b/src/features/PlannerItems.tsx
@@ -74,7 +74,7 @@ const PlannerItems = () => {
     if (data.length && user.isCanvasOptIn === true) {
       return (
         <List>
-          {data.map(({ plannable_id, plannable_type, html_url, plannable: { title, due_at } }) => (
+          {data.map(({ plannable_id, plannable_date, html_url, plannable: { title } }) => (
             <ListItem key={plannable_id}>
               <ListItemContentLink
                 href={canvasUrl(html_url)}
@@ -87,9 +87,9 @@ const PlannerItems = () => {
                 <ListItemText>
                   <ListItemHeader>{title}</ListItemHeader>
                   <ListItemDescription>
-                    {plannable_type !== ('calendar_event' || 'announcement')
-                      ? `Due ${format(due_at, 'MMM Do [at] h:mma')}`
-                      : ''}
+                    {plannable_date &&
+                      plannable_date !== '' &&
+                      format(plannable_date, 'MMM Do [at] h:mma')}
                   </ListItemDescription>
                 </ListItemText>
               </ListItemContentLink>

--- a/src/features/ScheduleCard.tsx
+++ b/src/features/ScheduleCard.tsx
@@ -38,7 +38,7 @@ const ScheduleCard = () => {
   let selectedPlannerItems: any[] = [];
   if (user.isCanvasOptIn) {
     selectedPlannerItems = plannerItems.data.filter(item =>
-      item.plannable.due_at ? isSameDay(item.plannable.due_at, selectedDay) : ''
+      item.plannable_date ? isSameDay(item.plannable_date, selectedDay) : ''
     );
   }
 
@@ -61,7 +61,7 @@ const ScheduleCard = () => {
         let plannerItemsOnDay: any[] = [];
         if (user.isCanvasOptIn) {
           plannerItemsOnDay = plannerItems.data.filter(item =>
-            item.plannable.due_at ? isSameDay(item.plannable.due_at, day) : ''
+            item.plannable_date ? isSameDay(item.plannable_date, day) : ''
           );
         }
 

--- a/src/features/__tests__/PlannerItems.test.tsx
+++ b/src/features/__tests__/PlannerItems.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { waitForElement, fireEvent } from '@testing-library/react';
-import { render } from '../../util/test-utils';
+import { render, mockAppContext } from '../../util/test-utils';
 import mockPlannerItems from '../../api/student/__mocks__/plannerItems.data';
 import PlannerItems from '../PlannerItems';
 import { mockGAEvent } from '../../setupTests';
@@ -51,22 +51,22 @@ describe('with an InfoButton in the CardFooter', () => {
   const validIinfoButtonId = 'canvas';
 
   test('does not display the button when the infoButtonData is missing it', async () => {
-    const { queryByTestId } = render(<PlannerItems />, {
-      appContext: {
-        infoButtonData: [{ id: 'invalid-id', content: 'content', title: 'title' }]
-      }
-    });
+    const testAppContext = {
+      ...mockAppContext,
+      infoButtonData: [{ id: 'invalid-id', content: 'content', title: 'title' }]
+    };
+    const { queryByTestId } = render(<PlannerItems />, { appContext: testAppContext });
 
     const element = queryByTestId(validIinfoButtonId);
     expect(element).not.toBeInTheDocument();
   });
 
   test('displays the button when the infoButtonData is included', async () => {
-    const { getByTestId } = render(<PlannerItems />, {
-      appContext: {
-        infoButtonData: [{ id: validIinfoButtonId, content: 'content', title: 'title' }]
-      }
-    });
+    const testAppContext = {
+      ...mockAppContext,
+      infoButtonData: [{ id: validIinfoButtonId, content: 'content', title: 'title' }]
+    };
+    const { getByTestId } = render(<PlannerItems />, { appContext: testAppContext });
 
     const element = await waitForElement(() => getByTestId(validIinfoButtonId));
     expect(element).toBeInTheDocument();

--- a/src/features/schedule/ScheduleCardAssignments.tsx
+++ b/src/features/schedule/ScheduleCardAssignments.tsx
@@ -35,7 +35,7 @@ const ScheduleCardAssignments = ({ selectedPlannerItems }) => {
         {user.isCanvasOptIn &&
           selectedPlannerItems.length > 0 &&
           selectedPlannerItems.map(
-            ({ plannable_id, html_url, plannable_type, plannable: { title, due_at } }) => (
+            ({ plannable_id, html_url, plannable_type, plannable_date, plannable: { title } }) => (
               <ListItem key={plannable_id}>
                 <ListItemContentLink
                   href={Url.canvas.main + html_url}
@@ -48,7 +48,7 @@ const ScheduleCardAssignments = ({ selectedPlannerItems }) => {
                     <ListItemHeader>{title} </ListItemHeader>
                     <ListItemDescription>
                       {plannable_type !== 'announcement'
-                        ? `Due ${format(due_at, 'MMM Do [at] h:mma')}`
+                        ? `Due ${format(plannable_date, 'MMM Do [at] h:mma')}`
                         : ''}
                     </ListItemDescription>
                   </ListItemText>

--- a/src/util/test-utils.tsx
+++ b/src/util/test-utils.tsx
@@ -38,7 +38,7 @@ const renderWithUserContext = (ui, { user = authUser, ...options } = {}) => {
   return testingLibraryRender(ui, { wrapper: Wrapper, ...options });
 };
 
-const mockAppContext: IAppContext = {
+export const mockAppContext: IAppContext = {
   infoButtonData: [{ id: 'info-button-id', content: 'Info button content', title: 'Title' }],
   appVersions: {
     serverVersion: 'server-test-123',


### PR DESCRIPTION
See Canvas code for how it sets the plannable_date given the different planner item types : https://github.com/instructure/canvas-lms/blob/stable/lib/api/v1/planner_item.rb#L39-L103

As per a discussion with Matt H., the PlannerItems just shows the date and lets the user make sense of the type of date it is (announcement, calendar event, assignment, etc)

fixes https://jira.sig.oregonstate.edu/browse/DD-649