### PR TITLE
Fixes for workshops that only happen on a day

### DIFF
--- a/src/api/student/__mocks__/courses.data.ts
+++ b/src/api/student/__mocks__/courses.data.ts
@@ -49,7 +49,7 @@ export default {
             creditHourSession: 3,
             scheduleType: 'A',
             scheduleDescription: 'Lecture',
-            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'Sa', 'Su']
           }
         ]
       }
@@ -99,7 +99,7 @@ export default {
             creditHourSession: 1,
             scheduleType: 'C',
             scheduleDescription: 'Recitation',
-            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'Sa', 'Su']
           }
         ]
       }
@@ -332,7 +332,7 @@ export default {
             creditHourSession: 4,
             scheduleType: 'A',
             scheduleDescription: 'Lecture',
-            weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'S']
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'Sa', 'Su']
           },
           {
             beginDate: '2017-12-06',
@@ -362,7 +362,7 @@ export default {
             creditHourSession: 0,
             scheduleType: 'A',
             scheduleDescription: 'Lecture',
-            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'Sa', 'Su']
           }
         ]
       }
@@ -549,7 +549,7 @@ export default {
             creditHourSession: 0,
             scheduleType: "W",
             scheduleDescription: "Workshop",
-            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'Sa', 'Su']
           },
           {
             beginDate: beginDate,
@@ -565,7 +565,7 @@ export default {
             creditHourSession: 2,
             scheduleType: "W",
             scheduleDescription: "Workshop",
-            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'Sa', 'Su']
           }
         ]
       }
@@ -616,7 +616,7 @@ export default {
             creditHourSession: 0,
             scheduleType: "W",
             scheduleDescription: "Workshop",
-            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'Sa', 'Su']
           },
           {
             beginDate: beginPastDate,
@@ -632,7 +632,7 @@ export default {
             creditHourSession: 2,
             scheduleType: "W",
             scheduleDescription: "Workshop",
-            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'Sa', 'Su']
           }
         ]
       }

--- a/src/api/student/__mocks__/courses.data.ts
+++ b/src/api/student/__mocks__/courses.data.ts
@@ -1,3 +1,7 @@
+const beginDate = new Date(Date.now()-(1000*60*60*24)).toISOString().slice(0,10);
+const endDate = new Date(Date.now()).toISOString().slice(0,10);
+const beginPastDate = new Date(Date.now()-(1000*60*60*24*10)).toISOString().slice(0,10);
+const endPastDate = new Date(Date.now()-(1000*60*60*24*5)).toISOString().slice(0,10);
 export default {
   data: [
     {
@@ -33,9 +37,9 @@ export default {
         ],
         meetingTimes: [
           {
-            beginDate: '2017-09-20',
+            beginDate: beginDate,
             beginTime: '10:00:00',
-            endDate: '2017-12-01',
+            endDate: endDate,
             endTime: '10:50:00',
             room: '123',
             building: 'SMB',
@@ -83,9 +87,9 @@ export default {
         ],
         meetingTimes: [
           {
-            beginDate: '2017-09-20',
+            beginDate: beginDate,
             beginTime: '09:00:00',
-            endDate: '2017-12-01',
+            endDate: endDate,
             endTime: '09:50:00',
             room: '285',
             building: 'WNGR',
@@ -133,9 +137,9 @@ export default {
         ],
         meetingTimes: [
           {
-            beginDate: '2017-12-07',
+            beginDate: beginDate,
             beginTime: '09:30:00',
-            endDate: '2017-12-07',
+            endDate: endDate,
             endTime: '11:20:00',
             room: '305',
             building: 'PHAR',
@@ -148,9 +152,9 @@ export default {
             weeklySchedule: ['Th']
           },
           {
-            beginDate: '2017-09-20',
+            beginDate: beginDate,
             beginTime: '11:00:00',
-            endDate: '2017-12-01',
+            endDate: endDate,
             endTime: '11:50:00',
             room: '305',
             building: 'PHAR',
@@ -198,9 +202,9 @@ export default {
         ],
         meetingTimes: [
           {
-            beginDate: '2017-09-20',
+            beginDate: beginDate,
             beginTime: '10:00:00',
-            endDate: '2017-12-01',
+            endDate: endDate,
             endTime: '10:50:00',
             room: '110',
             building: 'STAG',
@@ -248,9 +252,9 @@ export default {
         ],
         meetingTimes: [
           {
-            beginDate: '2017-09-20',
+            beginDate: beginDate,
             beginTime: '15:00:00',
-            endDate: '2017-12-01',
+            endDate: endDate,
             endTime: '15:50:00',
             room: '210',
             building: 'LINC',
@@ -316,9 +320,9 @@ export default {
         ],
         meetingTimes: [
           {
-            beginDate: '2017-09-20',
+            beginDate: beginDate,
             beginTime: '16:00:00',
-            endDate: '2017-12-01',
+            endDate: endDate,
             endTime: '16:50:00',
             room: '151',
             building: 'WNGR',
@@ -331,9 +335,9 @@ export default {
             weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'S']
           },
           {
-            beginDate: '2017-12-06',
+            beginDate: beginDate,
             beginTime: '16:00:00',
-            endDate: '2017-12-06',
+            endDate: endDate,
             endTime: '17:50:00',
             room: 'FNL',
             building: 'GRP',
@@ -346,9 +350,9 @@ export default {
             weeklySchedule: ['W']
           },
           {
-            beginDate: '2017-09-20',
+            beginDate: beginDate,
             beginTime: '20:30:00',
-            endDate: '2017-12-01',
+            endDate: endDate,
             endTime: '21:50:00',
             room: 'MID',
             building: 'GRP',
@@ -414,9 +418,9 @@ export default {
         ],
         meetingTimes: [
           {
-            beginDate: '2017-09-20',
+            beginDate: beginDate,
             beginTime: '14:00:00',
-            endDate: '2017-12-01',
+            endDate: endDate,
             endTime: '15:50:00',
             room: '212',
             building: 'WNGR',
@@ -482,9 +486,9 @@ export default {
         ],
         meetingTimes: [
           {
-            beginDate: '2017-09-20',
+            beginDate: beginDate,
             beginTime: '14:00:00',
-            endDate: '2017-12-01',
+            endDate: endDate,
             endTime: '15:50:00',
             room: '238',
             building: 'WNGR',
@@ -495,6 +499,148 @@ export default {
             scheduleType: 'D',
             scheduleDescription: 'Laboratory',
             weeklySchedule: ['T']
+          }
+        ]
+      }
+    },
+    {
+      type: "class-schedule",
+      id: "bogus-id-9",
+      links: {
+        self: null
+      },
+      attributes: {
+        academicYear: '1920',
+        academicYearDescription: "Academic Year 2019-20",
+        courseReferenceNumber: "17179",
+        courseSubject: "ED",
+        courseSubjectDescription: "Education",
+        courseNumber: "408",
+        courseTitle: "WORKSHOP/SEPT EXP SECONDARY",
+        sectionNumber: "001",
+        term: "202001",
+        termDescription: "Fall 2019",
+        scheduleDescription: "Workshop",
+        scheduleType: "W",
+        creditHours: 2,
+        registrationStatus: "**Web Registered**",
+        gradingMode: "Normal Grading Mode",
+        continuingEducation: false,
+        faculty: [
+          {
+            osuId: "1234567895",
+            name: "McGrory, Sue",
+            email: null,
+            primary: true
+          }
+        ],
+        meetingTimes: [
+          {
+            beginDate: beginPastDate,
+            beginTime: "09:00:00",
+            endDate: endPastDate,
+            endTime: "14:50:00",
+            room: "101",
+            building: "FURM",
+            buildingDescription: "Joyce Collin Furman Hall Old",
+            campusCode: "C",
+            campus: " Oregon State - Corvallis",
+            hoursPerWeek: 5.83,
+            creditHourSession: 0,
+            scheduleType: "W",
+            scheduleDescription: "Workshop",
+            weeklySchedule: [
+              "T"
+            ]
+          },
+          {
+            beginDate: beginDate,
+            beginTime: "09:00:00",
+            endDate: endDate,
+            endTime: "14:50:00",
+            room: "101",
+            building: "FURM",
+            buildingDescription: "Joyce Collin Furman Hall",
+            campusCode: "C",
+            campus: " Oregon State - Corvallis",
+            hoursPerWeek: 5.83,
+            creditHourSession: 2,
+            scheduleType: "W",
+            scheduleDescription: "Workshop",
+            weeklySchedule: [
+              "F"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      type: "class-schedule",
+      id: "bogus-id-10",
+      links: {
+        self: null
+      },
+      attributes: {
+        academicYear: '1920',
+        academicYearDescription: "Academic Year 2019-20",
+        courseReferenceNumber: "17179",
+        courseSubject: "ED",
+        courseSubjectDescription: "Education",
+        courseNumber: "408",
+        courseTitle: "WORKSHOP/SEPT EXP SECONDARY",
+        sectionNumber: "001",
+        term: "202001",
+        termDescription: "Fall 2019",
+        scheduleDescription: "Workshop",
+        scheduleType: "W",
+        creditHours: 2,
+        registrationStatus: "**Web Registered**",
+        gradingMode: "Normal Grading Mode",
+        continuingEducation: false,
+        faculty: [
+          {
+            osuId: "1234567895",
+            name: "McGrory, Sue",
+            email: null,
+            primary: true
+          }
+        ],
+        meetingTimes: [
+          {
+            beginDate: beginPastDate,
+            beginTime: "09:00:00",
+            endDate: endPastDate,
+            endTime: "14:50:00",
+            room: "101",
+            building: "FURM",
+            buildingDescription: "Joyce Collin Furman Hall Past",
+            campusCode: "C",
+            campus: " Oregon State - Corvallis",
+            hoursPerWeek: 5.83,
+            creditHourSession: 0,
+            scheduleType: "W",
+            scheduleDescription: "Workshop",
+            weeklySchedule: [
+              "T"
+            ]
+          },
+          {
+            beginDate: beginPastDate,
+            beginTime: "09:00:00",
+            endDate: endPastDate,
+            endTime: "14:50:00",
+            room: "101",
+            building: "FURM",
+            buildingDescription: "Joyce Collin Furman Hall Past",
+            campusCode: "C",
+            campus: " Oregon State - Corvallis",
+            hoursPerWeek: 5.83,
+            creditHourSession: 2,
+            scheduleType: "W",
+            scheduleDescription: "Workshop",
+            weeklySchedule: [
+              "F"
+            ]
           }
         ]
       }

--- a/src/api/student/__mocks__/courses.data.ts
+++ b/src/api/student/__mocks__/courses.data.ts
@@ -335,9 +335,9 @@ export default {
             weeklySchedule: ['M', 'T', 'W', 'Th', 'F', 'S']
           },
           {
-            beginDate: beginDate,
+            beginDate: '2017-12-06',
             beginTime: '16:00:00',
-            endDate: endDate,
+            endDate: '2017-12-06',
             endTime: '17:50:00',
             room: 'FNL',
             building: 'GRP',

--- a/src/api/student/__mocks__/courses.data.ts
+++ b/src/api/student/__mocks__/courses.data.ts
@@ -549,9 +549,7 @@ export default {
             creditHourSession: 0,
             scheduleType: "W",
             scheduleDescription: "Workshop",
-            weeklySchedule: [
-              "T"
-            ]
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
           },
           {
             beginDate: beginDate,
@@ -567,9 +565,7 @@ export default {
             creditHourSession: 2,
             scheduleType: "W",
             scheduleDescription: "Workshop",
-            weeklySchedule: [
-              "F"
-            ]
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
           }
         ]
       }
@@ -620,9 +616,7 @@ export default {
             creditHourSession: 0,
             scheduleType: "W",
             scheduleDescription: "Workshop",
-            weeklySchedule: [
-              "T"
-            ]
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
           },
           {
             beginDate: beginPastDate,
@@ -638,9 +632,7 @@ export default {
             creditHourSession: 2,
             scheduleType: "W",
             scheduleDescription: "Workshop",
-            weeklySchedule: [
-              "F"
-            ]
+            weeklySchedule: ['M', 'T', 'W', 'Th', 'F']
           }
         ]
       }

--- a/src/features/ScheduleCard.tsx
+++ b/src/features/ScheduleCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
-import { isSameDay, format } from 'date-fns';
+import { isSameDay, format, isBefore, isAfter, isWithinRange } from 'date-fns';
 import VisuallyHidden from '@reach/visually-hidden';
 import { useCourseSchedule, usePlannerItems } from '../api/student';
 import { useAcademicCalendarEvents } from '../api/events';
@@ -32,7 +32,12 @@ const ScheduleCard = () => {
 
   const getCoursesOnSelectedDay = () => {
     const selectedDayShortcode = getDayShortcode(selectedDay);
-    return coursesOnDay(courses.data, selectedDayShortcode);
+    return coursesOnDay(courses.data, selectedDayShortcode).filter(course => {
+      course.attributes.meetingTimes = course.attributes.meetingTimes.filter(meeting =>
+        isWithinRange(selectedDay, meeting.beginDate, meeting.endDate)
+      );
+      return course.attributes.meetingTimes.length;
+    });
   };
 
   let selectedPlannerItems: any[] = [];

--- a/src/features/__tests__/Courses.test.tsx
+++ b/src/features/__tests__/Courses.test.tsx
@@ -28,7 +28,7 @@ describe('<Courses />', () => {
 
   it('Finds "8" as the course count in the Badge', async () => {
     const { getByText } = render(<Courses />);
-    const NumCourses = await waitForElement(() => getByText('8'));
+    const NumCourses = await waitForElement(() => getByText('10'));
     expect(NumCourses).toBeInTheDocument();
   });
 
@@ -39,6 +39,8 @@ describe('<Courses />', () => {
       'CS 261',
       'CS 261',
       'CS 290',
+      'ED 408',
+      'ED 408',
       'PH 212',
       'PH 212',
       'PH 212',

--- a/src/features/__tests__/ScheduleCard.test.tsx
+++ b/src/features/__tests__/ScheduleCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { wait, waitForElement, fireEvent } from '@testing-library/react';
+import { wait, waitForElement, fireEvent, getAllByText, getByTestId, getAllByTestId, getByTitle, getByLabelText } from '@testing-library/react';
 import { renderWithUserContext, authUser } from '../../util/test-utils';
 import { academicCalendar3 } from '../../api/__mocks__/academicCalendar.data';
 import mockPlannerItems from '../../api/student/__mocks__/plannerItems.data';
@@ -39,6 +39,13 @@ describe('<ScheduleCard /> with data and canvas authorized user', () => {
 
     const todayCourse = await waitForElement(() => getByText(/Every Day Test/));
     expect(todayCourse).toBeInTheDocument();
+  });
+
+  it('should find one workshop', async () => {
+    const { container, queryByText } = renderWithUserContext(<ScheduleCard />);
+    const todayWorkshop = await waitForElement(() => getAllByText(container, /Workshop/))
+    expect(todayWorkshop).toHaveLength(1);
+    expect(queryByText('Joyce Collin Furman Hall Old')).not.toBeInTheDocument();
   });
 
   it('should find a course with a clickable map link', async () => {

--- a/src/features/__tests__/ScheduleCard.test.tsx
+++ b/src/features/__tests__/ScheduleCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { wait, waitForElement, fireEvent, getAllByText, getByTestId, getAllByTestId, getByTitle, getByLabelText } from '@testing-library/react';
+import { wait, waitForElement, fireEvent, getAllByText } from '@testing-library/react';
 import { renderWithUserContext, authUser } from '../../util/test-utils';
 import { academicCalendar3 } from '../../api/__mocks__/academicCalendar.data';
 import mockPlannerItems from '../../api/student/__mocks__/plannerItems.data';


### PR DESCRIPTION
This fixes the bug dd-661. We had some data with workshops that only happen on a day and we needed a way to filter them out when that day has passed, or not occurred yet.