### PR TITLE
Implement date instead of icon for schedule card academic calendar

### DIFF
--- a/src/features/schedule/ScheduleCardAcademicCalendar.tsx
+++ b/src/features/schedule/ScheduleCardAcademicCalendar.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { faCalendarCheck } from '@fortawesome/pro-light-svg-icons';
 import { CardSection, SectionHeader } from './ScheduleCardStyles';
-import Icon from '../../ui/Icon';
-import { Color } from '../../theme';
 import { List, ListItem, ListItemHeader, ListItemText, ListItemContentLink } from '../../ui/List';
 import { Event } from '../../util/gaTracking';
+import { Date, DateDay, DateMonth } from '../../ui/Date';
+import { format } from 'date-fns';
 
 const ScheduleCardAcademicCalendar = ({ calEvents }) => (
   <>
@@ -12,7 +11,7 @@ const ScheduleCardAcademicCalendar = ({ calEvents }) => (
       <CardSection>
         <SectionHeader>Academic Calendar</SectionHeader>
         <List>
-          {calEvents.map(({ title, link }) => (
+          {calEvents.map(({ title, link, pubDate}) => (
             <ListItem key={title}>
               <ListItemContentLink
                 href={link}
@@ -20,7 +19,10 @@ const ScheduleCardAcademicCalendar = ({ calEvents }) => (
                 rel="noopener noreferrer"
                 onClick={() => Event('schedule-card', 'academic-calendar-link', link)}
               >
-                <Icon icon={faCalendarCheck} color={Color['orange-200']} />
+                <Date>
+                  <DateDay>{format(pubDate, 'D')}</DateDay>
+                  <DateMonth>{format(pubDate, 'MMM')}</DateMonth>
+                </Date>
                 <ListItemText>
                   <ListItemHeader>{title} </ListItemHeader>
                 </ListItemText>

--- a/src/ui/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/ui/__tests__/__snapshots__/Button.test.tsx.snap
@@ -235,10 +235,10 @@ exports[`Renders default CloseButton with the SVG close icon 1`] = `
       fill="currentColor"
     />
   </svg>
-  <span
-    style="display: block; border: 0px; height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; position: absolute;"
+  <div
+    style="border: 0px; height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; position: absolute;"
   >
     Close
-  </span>
+  </div>
 </button>
 `;

--- a/src/ui/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/ui/__tests__/__snapshots__/Button.test.tsx.snap
@@ -235,10 +235,10 @@ exports[`Renders default CloseButton with the SVG close icon 1`] = `
       fill="currentColor"
     />
   </svg>
-  <div
-    style="border: 0px; height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; position: absolute;"
+  <span
+    style="display: block; border: 0px; height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; position: absolute;"
   >
     Close
-  </div>
+  </span>
 </button>
 `;


### PR DESCRIPTION
In the Schedule Card Component, display the date of an academic calendar event instead of Icon.