### PR TITLE
DD-654: Add Course Info Modal to Schedule Card

### DIFF
--- a/src/features/ScheduleCard.tsx
+++ b/src/features/ScheduleCard.tsx
@@ -2,17 +2,17 @@ import React, { useState, useContext, useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import { isSameDay, format, isWithinRange } from 'date-fns';
 import VisuallyHidden from '@reach/visually-hidden';
-import { useCourseSchedule, usePlannerItems } from '../api/student';
-import { useAcademicCalendarEvents } from '../api/events';
-import { UserContext } from '../App';
-import { getNextFiveDays, getDayShortcode, coursesOnDay } from './schedule/schedule-utils';
 import {
   ScheduleCardDayMenu,
   ScheduleCardCourses,
   ScheduleCardAssignments,
   ScheduleCardAcademicCalendar
 } from './schedule';
+import { getNextFiveDays, getDayShortcode, coursesOnDay } from './schedule/schedule-utils';
 import { Header } from './schedule/ScheduleCardStyles';
+import { useAcademicCalendarEvents } from '../api/events';
+import { useCourseSchedule, usePlannerItems } from '../api/student';
+import { UserContext } from '../App';
 import { Card, CardFooter, CardContent } from '../ui/Card';
 
 /**
@@ -32,6 +32,7 @@ const ScheduleCard = () => {
 
   const getCoursesOnSelectedDay = () => {
     const selectedDayShortcode = getDayShortcode(selectedDay);
+
     return coursesOnDay(courses.data, selectedDayShortcode).filter(course => {
       course.attributes.meetingTimes = course.attributes.meetingTimes.filter(meeting =>
         isWithinRange(selectedDay, meeting.beginDate, meeting.endDate)

--- a/src/features/__tests__/ScheduleCardCourses.test.tsx
+++ b/src/features/__tests__/ScheduleCardCourses.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { fireEvent, waitForElement, cleanup } from '@testing-library/react';
+import { render } from '../../util/test-utils';
+import { ScheduleCardCourses } from '../schedule/ScheduleCardCourses';
+
+const mockCourse = {
+  attributes: {
+    academicYear: '1920',
+    academicYearDescription: 'Academic Year 2019-20',
+    continuingEducation: false,
+    courseNumber: '599',
+    courseReferenceNumber: '19708',
+    courseSubject: 'ENGR',
+    courseSubjectDescription: 'Engineering Science',
+    courseTitle: 'TEST COURSE',
+    creditHours: 1,
+    faculty: [
+      {
+        email: 'nobody@testing.com',
+        name: 'N/A',
+        primary: true
+      }
+    ],
+    gradingMode: 'Normal Grading Mode',
+    meetingTimes: [
+      {
+        beginDate: '2019-09-25',
+        beginTime: '08:00:00',
+        building: 'BEXL',
+        buildingDescription: 'Bexell Hall',
+        campus: ' Oregon State - Corvallis',
+        campusCode: 'C',
+        creditHourSession: 1,
+        endDate: '2019-12-06',
+        endTime: '08:50:00',
+        hoursPerWeek: 0.83,
+        room: '321',
+        scheduleDescription: 'Lecture',
+        scheduleType: 'A',
+        weeklySchedule: ['Th']
+      }
+    ],
+    registrationStatus: '**Web Registered**',
+    scheduleDescription: 'Lecture',
+    scheduleType: 'A',
+    sectionNumber: '003',
+    term: '202001',
+    termDescription: 'Fall 2019'
+  },
+  id: 'bogus-id-4',
+  links: { self: null },
+  type: 'class-schedule'
+};
+
+describe('<ScheduleCardCourses />', () => {
+  it('Renders both with a course, and with no courses', () => {
+    render(<ScheduleCardCourses selectedCourses={[mockCourse]} />);
+    cleanup();
+    render(<ScheduleCardCourses selectedCourses={[]} />);
+  });
+
+  it('Specific course loads on click, close button closes', async () => {
+    const { getByText, getByTestId, queryByTestId } = render(
+      <ScheduleCardCourses selectedCourses={[mockCourse]} />
+    );
+    expect(() => getByText('ERROR')).toThrow(); // Testing to make sure stuff we aren't expecting will throw
+    const OpSysBtn = await waitForElement(() => getByText('ENGR')); // Throws if mockCourse doesn't load
+    fireEvent.click(OpSysBtn);
+    const courseDialog = await waitForElement(() => getByTestId('course-dialog'));
+    expect(courseDialog).toBeInTheDocument();
+    expect(courseDialog).toHaveTextContent(/test course/i);
+    const closeBtn = await waitForElement(() => getByText('Close'));
+    fireEvent.click(closeBtn);
+    expect(queryByTestId('course-dialog')).toBeNull();
+  });
+});

--- a/src/features/__tests__/ScheduleCardCourses.test.tsx
+++ b/src/features/__tests__/ScheduleCardCourses.test.tsx
@@ -2,73 +2,28 @@ import React from 'react';
 import { fireEvent, waitForElement, cleanup } from '@testing-library/react';
 import { render } from '../../util/test-utils';
 import { ScheduleCardCourses } from '../schedule/ScheduleCardCourses';
-
-const mockCourse = {
-  attributes: {
-    academicYear: '1920',
-    academicYearDescription: 'Academic Year 2019-20',
-    continuingEducation: false,
-    courseNumber: '599',
-    courseReferenceNumber: '19708',
-    courseSubject: 'ENGR',
-    courseSubjectDescription: 'Engineering Science',
-    courseTitle: 'TEST COURSE',
-    creditHours: 1,
-    faculty: [
-      {
-        email: 'nobody@testing.com',
-        name: 'N/A',
-        primary: true
-      }
-    ],
-    gradingMode: 'Normal Grading Mode',
-    meetingTimes: [
-      {
-        beginDate: '2019-09-25',
-        beginTime: '08:00:00',
-        building: 'BEXL',
-        buildingDescription: 'Bexell Hall',
-        campus: ' Oregon State - Corvallis',
-        campusCode: 'C',
-        creditHourSession: 1,
-        endDate: '2019-12-06',
-        endTime: '08:50:00',
-        hoursPerWeek: 0.83,
-        room: '321',
-        scheduleDescription: 'Lecture',
-        scheduleType: 'A',
-        weeklySchedule: ['Th']
-      }
-    ],
-    registrationStatus: '**Web Registered**',
-    scheduleDescription: 'Lecture',
-    scheduleType: 'A',
-    sectionNumber: '003',
-    term: '202001',
-    termDescription: 'Fall 2019'
-  },
-  id: 'bogus-id-4',
-  links: { self: null },
-  type: 'class-schedule'
-};
+import mockCourses from '../../api/student/__mocks__/courses.data';
 
 describe('<ScheduleCardCourses />', () => {
-  it('Renders both with a course, and with no courses', () => {
-    render(<ScheduleCardCourses selectedCourses={[mockCourse]} />);
-    cleanup();
+  it('Renders with no courses', () => {
     render(<ScheduleCardCourses selectedCourses={[]} />);
+  })
+
+  it('Renders both with courses', () => {
+    render(<ScheduleCardCourses selectedCourses={mockCourses.data} />);
   });
 
   it('Specific course loads on click, close button closes', async () => {
-    const { getByText, getByTestId, queryByTestId } = render(
-      <ScheduleCardCourses selectedCourses={[mockCourse]} />
+    const { queryAllByText, getByText, getByTestId, queryByTestId } = render(
+      <ScheduleCardCourses selectedCourses={mockCourses.data} />
     );
-    expect(() => getByText('ERROR')).toThrow(); // Testing to make sure stuff we aren't expecting will throw
-    const OpSysBtn = await waitForElement(() => getByText('ENGR')); // Throws if mockCourse doesn't load
+    const wrCourses = await waitForElement(() => queryAllByText('WR'))
+    expect(wrCourses.length).toBeGreaterThan(0) // since queryAll can return an empty array, we want to make sure that didn't happen
+    const OpSysBtn = wrCourses[0] // we really don't care what course we click for this test
     fireEvent.click(OpSysBtn);
     const courseDialog = await waitForElement(() => getByTestId('course-dialog'));
     expect(courseDialog).toBeInTheDocument();
-    expect(courseDialog).toHaveTextContent(/test course/i);
+    expect(courseDialog).toHaveTextContent(/WR/i);
     const closeBtn = await waitForElement(() => getByText('Close'));
     fireEvent.click(closeBtn);
     expect(queryByTestId('course-dialog')).toBeNull();

--- a/src/features/schedule/ScheduleCardCourses.tsx
+++ b/src/features/schedule/ScheduleCardCourses.tsx
@@ -15,7 +15,7 @@ import {
   ICourseSchedule,
   IMeetingTime
 } from '../../api/student/course-schedule';
-import zcourses from '../../assets/courses.svg';
+import coursesSvg from '../../assets/courses.svg';
 import Course from '../../features/Course';
 import { theme, Color } from '../../theme';
 import Icon from '../../ui/Icon';
@@ -107,7 +107,7 @@ const ScheduleCardCourses = (props: ScheduleCardCoursesProps) => {
           selectedCourses.map((c: ICourseSchedule) => meetingTimeListItems(c))}
         {selectedCourses.length === 0 && (
           <NoItems as="li">
-            <NoItemsImage src={zcourses} alt="" />
+            <NoItemsImage src={coursesSvg} alt="" />
             <NoItemsText>You don&apos;t have any courses scheduled</NoItemsText>
           </NoItems>
         )}

--- a/src/features/schedule/ScheduleCardCourses.tsx
+++ b/src/features/schedule/ScheduleCardCourses.tsx
@@ -100,7 +100,6 @@ const ScheduleCardCourses = (props: ScheduleCardCoursesProps) => {
 
   return (
     <CardSection>
-      {/* TODO: course should NOT be a link */}
       <SectionHeader>Courses</SectionHeader>
       <List>
         {selectedCourses.length > 0 &&


### PR DESCRIPTION
Added the modal functionality to the dashboard that we see with courses on the academic page. 

**Tests check for** 

- ScheduleCardCourses ability to render both with and without courses
- That the course gets loaded in, we are able to click it to open the modal, and that we are able to close the modal