### PR TITLE
renders multiple stacked release notes content cards

### DIFF
--- a/src/features/__tests__/BetaDashboard.test.tsx
+++ b/src/features/__tests__/BetaDashboard.test.tsx
@@ -13,6 +13,7 @@ const mockUseReleaseNotes = jest.fn();
 
 jest.mock('@osu-wams/hooks', () => {
   return {
+    // @ts-ignore spreading warning
     ...jest.requireActual('@osu-wams/hooks'),
     usePageContent: () => mockUsePageContent(),
     useReleaseNotes: () => mockUseReleaseNotes(),
@@ -42,10 +43,10 @@ describe('<BetaDashboard />', () => {
     expect(await findByText('beta list item', { selector: 'li' })).toBeInTheDocument();
   });
 
-  it('should find the release notes card with appripriate content', async () => {
+  it('should find the release notes card with appropriate content', async () => {
     const { findByText } = render(<BetaDashboard />);
+    expect(await findByText('Release : Winter test 2019')).toBeInTheDocument();
     expect(await findByText('Test Release Note')).toBeInTheDocument();
-    expect(await findByText('Winter test 2019')).toBeInTheDocument();
     expect(await findByText(/test release note body content/i)).toBeInTheDocument();
   });
 

--- a/src/features/beta/BetaReleaseNotes.tsx
+++ b/src/features/beta/BetaReleaseNotes.tsx
@@ -9,15 +9,22 @@ const BetaReleaseNotes: FC = () => {
   const releaseNotes = useReleaseNotes();
 
   return (
-    <Card>
-      <CardHeader title="Release Notes" badge={<CardIcon icon={faClipboardListCheck} />} />
-      <CardContent>
-        <ReleaseTitle>{releaseNotes.data[0]?.title}</ReleaseTitle>
-        <ReleaseSubtitle>{releaseNotes.data[0]?.date}</ReleaseSubtitle>
-        <div dangerouslySetInnerHTML={{ __html: releaseNotes.data[0]?.content }}></div>
-      </CardContent>
-      <CardFooter></CardFooter>
-    </Card>
+    <>
+      {releaseNotes.data.length &&
+        releaseNotes.data.map((releaseNote, i) => (
+          <Card key={`release-notes-${i}`}>
+            <CardHeader
+              title={`Release : ${releaseNote?.date}`}
+              badge={<CardIcon icon={faClipboardListCheck} />}
+            />
+            <CardContent>
+              <ReleaseTitle>{releaseNote?.title}</ReleaseTitle>
+              <div dangerouslySetInnerHTML={{ __html: releaseNote?.content }}></div>
+            </CardContent>
+            <CardFooter></CardFooter>
+          </Card>
+        ))}
+    </>
   );
 };
 

--- a/src/pages/BetaDashboard.tsx
+++ b/src/pages/BetaDashboard.tsx
@@ -11,8 +11,8 @@ const BetaDashboard = () => {
       <PageTitle title="Beta" />
       <Masonry>
         <BetaInfo />
-        <BetaResources />
         <BetaReleaseNotes />
+        <BetaResources />
       </Masonry>
     </MainGridWrapper>
   );


### PR DESCRIPTION
fixes front-end for https://jira.sig.oregonstate.edu/browse/DD-910 per discussion from MM

![local my oregonstate edu_3000_beta (2)](https://user-images.githubusercontent.com/32885/83547472-1ebe9b80-a4b7-11ea-8e3d-54f2a98ab9f4.png)
