### PR TITLE
mouse and keyboard event handlers to retain popover visibility

### DIFF
--- a/src/ui/HeaderNav/NotificationsMenu.tsx
+++ b/src/ui/HeaderNav/NotificationsMenu.tsx
@@ -196,7 +196,12 @@ const NotificationsMenu = () => {
                     {m.deliveredAt && <Date>{format(m.deliveredAt, "MMM do 'at' h a")}</Date>}
                   </div>
                   <Dismiss
-                    onClick={(event) => {
+                    onMouseUp={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      dismissNotification(m);
+                    }}
+                    onKeyDown={(event) => {
                       event.preventDefault();
                       event.stopPropagation();
                       dismissNotification(m);


### PR DESCRIPTION
Near the bottom of the page, Reach explains which events the elements use in conjunction with the menu visibility;

```
As such, events for each component look more like this:

MenuButton: Activates Menu in onMouseDown or onKeyDown (Enter or Spacebar keys)
MenuItem: Selects itself in onMouseUp or onKeyDown (Enter or Spacebar keys)
MenuLink: Selects itself in onMouseUp or onKeyDown (Enter or Spacebar keys).
For MenuLink, the click event is fired after the selection events. So if you only need to intercept the event that triggers the anchor link, you can still use onClick, but the rest of the event handlers called in MenuLink will still be which means the Menu will close and your onSelect handler will be triggered.
```