### PR TITLE
renders student gpa based on levelcode if specified

### DIFF
--- a/src/features/academic-overview/StudentGpa.tsx
+++ b/src/features/academic-overview/StudentGpa.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Loading } from 'src/ui/Loading';
 import {
   Highlight,
@@ -7,28 +7,38 @@ import {
   HighlightDescription,
 } from 'src/ui/Highlights';
 import { useGpa } from '@osu-wams/hooks';
+import { Types } from '@osu-wams/lib';
+import { useRecoilValue } from 'recoil';
+import { userState } from 'src/state/application';
 
 export const StudentGpa: React.FC = () => {
+  const user = useRecoilValue(userState);
   const { data, isLoading, isSuccess } = useGpa();
+  const [selectedGpa, setSelectedGpa] = useState<Types.GpaLevel>({
+    gpa: '',
+    level: '',
+    levelCode: '',
+    gpaType: '',
+  });
 
-  // We expect the first item in the array to be the primary one this is sorted in the server
-  const primaryGpa = () => {
-    if (data?.length) {
-      return data[0];
-    } else {
-      return { gpa: '', level: '', levelCode: '', gpaType: '' };
+  useEffect(() => {
+    if (data && data.length > 0 && user.data) {
+      const levelCode = user.data.classification.attributes?.levelCode;
+      // We expect the first item in the array to be the primary one this is sorted in the server
+      setSelectedGpa(data.find((g) => g.levelCode === levelCode) ?? data[0]);
     }
-  };
+  }, [data, user.data]);
+
   return (
     <Highlight textAlignLeft>
-      <HighlightEmphasis>{primaryGpa().gpa}</HighlightEmphasis>
+      <HighlightEmphasis>{selectedGpa.gpa}</HighlightEmphasis>
       <HighlightTitle marginTop={0}>Institutional GPA</HighlightTitle>
       {isLoading && <Loading lines={3} />}
       {isSuccess && (
         <>
           <HighlightDescription>
-            {primaryGpa().gpa !== ''
-              ? `${primaryGpa().level} GPA across all past terms.`
+            {selectedGpa.gpa !== ''
+              ? `${selectedGpa.level} GPA across all past terms.`
               : 'You must first complete a term to have a GPA.'}
           </HighlightDescription>
         </>


### PR DESCRIPTION
supersedes #315 based on final feedback;

> The original gpa terminology should remain the same.. the only change is that the GPA value should be the value for the level code that matches the user.
