### PR TITLE
get rid of extra comma on major/department

### DIFF
--- a/src/features/AcademicProgram.tsx
+++ b/src/features/AcademicProgram.tsx
@@ -80,8 +80,8 @@ const AcademicProgram = () => {
       return;
     }
 
-    if (fields && Array.isArray(fields) && fields[1] != null) {
-      fields = fields.join(', ');
+    if (fields && Array.isArray(fields)) {
+      fields = fields.filter(Boolean).join(', ');
     }
 
     return (

--- a/src/features/AcademicProgram.tsx
+++ b/src/features/AcademicProgram.tsx
@@ -80,7 +80,7 @@ const AcademicProgram = () => {
       return;
     }
 
-    if (fields && Array.isArray(fields) && fields.length > 1) {
+    if (fields && Array.isArray(fields) && fields[1] != null) {
       fields = fields.join(', ');
     }
 

--- a/src/features/__tests__/AcademicProgram.test.tsx
+++ b/src/features/__tests__/AcademicProgram.test.tsx
@@ -61,7 +61,7 @@ describe('<ProgramOfStudy /> | Degree', () => {
 
   describe('Graduated student', () => {
     it('in is not shown in degree', async () => {
-      let newApiData = apiData;
+      let newApiData = JSON.parse(JSON.stringify(apiData));
       newApiData[0].attributes.degree = 'Certificate in'; // is there a better way to do this??
 
       alterMock(DEGREES_API, newApiData);
@@ -72,7 +72,7 @@ describe('<ProgramOfStudy /> | Degree', () => {
 
     // When a student graduates, they have a major but no department
     it('no extra comma after major, since no department', async () => {
-      let newApiData = apiData;
+      let newApiData = JSON.parse(JSON.stringify(apiData));
       newApiData[0].attributes.majors.first.department = '';
       newApiData[0].attributes.majors.second.department = '';
 

--- a/src/features/__tests__/AcademicProgram.test.tsx
+++ b/src/features/__tests__/AcademicProgram.test.tsx
@@ -59,6 +59,35 @@ describe('<ProgramOfStudy /> | Degree', () => {
     });
   });
 
+  describe('Graduated student', () => {
+    it('in is not shown in degree', async () => {
+      let newApiData = apiData;
+      newApiData[0].attributes.degree = 'Certificate in'; // is there a better way to do this??
+
+      alterMock(DEGREES_API, newApiData);
+      render(<AcademicProgram />);
+
+      expect(await screen.findByText(/Certificate/i)).toBeInTheDocument();
+    });
+
+    // when a student graduates, they have a major but no department
+    it('no extra comma after major, since no department', async () => {
+      // get rid of departments in mock
+      let newApiData = apiData;
+      newApiData[0].attributes.majors.first.department = '';
+      newApiData[0].attributes.majors.second.department = '';
+
+      alterMock(DEGREES_API, newApiData);
+
+      render(<AcademicProgram />);
+
+      console.log('old api data: ', apiData[0].attributes.majors);
+      console.log('new api data: ', newApiData[0].attributes.majors);
+
+      expect(screen.queryByText(/, School of Mech, Ind, Manf Engr/i)).not.toBeInTheDocument();
+    });
+  });
+
   describe('Dual Degrees', () => {
     it('Has two sets of degree UI rendered', async () => {
       alterMock(DEGREES_API, [...apiData, ...apiData]);

--- a/src/features/__tests__/AcademicProgram.test.tsx
+++ b/src/features/__tests__/AcademicProgram.test.tsx
@@ -70,9 +70,8 @@ describe('<ProgramOfStudy /> | Degree', () => {
       expect(await screen.findByText(/Certificate/i)).toBeInTheDocument();
     });
 
-    // when a student graduates, they have a major but no department
+    // When a student graduates, they have a major but no department
     it('no extra comma after major, since no department', async () => {
-      // get rid of departments in mock
       let newApiData = apiData;
       newApiData[0].attributes.majors.first.department = '';
       newApiData[0].attributes.majors.second.department = '';
@@ -80,9 +79,6 @@ describe('<ProgramOfStudy /> | Degree', () => {
       alterMock(DEGREES_API, newApiData);
 
       render(<AcademicProgram />);
-
-      console.log('old api data: ', apiData[0].attributes.majors);
-      console.log('new api data: ', newApiData[0].attributes.majors);
 
       expect(screen.queryByText(/, School of Mech, Ind, Manf Engr/i)).not.toBeInTheDocument();
     });


### PR DESCRIPTION
get rid of extra comma that shows up on student's major/department after they've already graduated