### PR TITLE
add system status text to resource error message

### DIFF
--- a/src/features/__tests__/ResourcesCard.test.tsx
+++ b/src/features/__tests__/ResourcesCard.test.tsx
@@ -82,6 +82,17 @@ describe('<ResourcesCard />', () => {
 
     expect(await findByTestId('warning-icon')).toBeInTheDocument();
   });
+
+  it('should display warning message if resource with IT system down is clicked', async () => {
+    const { findByText, findAllByText } = render(<ResourcesCard categ="featured" icon={faStars} />);
+
+    render(<ITSystemStatus />);
+    const BoxResource = await findAllByText('Box');
+    userEvent.click(BoxResource[0]);
+
+    expect(await findByText(/Resource may be unavailable/i)).toBeInTheDocument();
+    expect(await findByText(/Performance Issues./i)).toBeInTheDocument();
+  });
 });
 
 describe('with an InfoButton in the CardFooter', () => {

--- a/src/features/resources/ResourceItem.tsx
+++ b/src/features/resources/ResourceItem.tsx
@@ -46,6 +46,7 @@ const ResourceItem = ({
   const { data, isSuccess } = useStatus();
   const [showDialog, setShowDialog] = useState(false);
   const [itSystemError, setItSystemError] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
   const [systemCheckedAt, setSystemCheckedAt] = useState(new Date());
   const open = () => setShowDialog(true);
   const close = () => setShowDialog(false);
@@ -89,6 +90,7 @@ const ResourceItem = ({
 
         if (resource.itSystem && result && result.status !== 1) {
           setItSystemError(true);
+          setErrorMsg(result.statusText);
         }
         // update date checked time
         setSystemCheckedAt(new Date());
@@ -170,7 +172,7 @@ const ResourceItem = ({
         </h2>
       </div>
 
-      <MyDialogContent column>
+      <MyDialogContent column style={{ paddingBottom: '0px' }}>
         <DateContainer>
           {resource.title} •{' '}
           {systemCheckedAt.toLocaleString('en-US', {
@@ -181,7 +183,10 @@ const ResourceItem = ({
             ' on ' +
             format(systemCheckedAt)}
         </DateContainer>
-        <p>We think there might be something wrong with this link. Open anyways?</p>
+        <p>
+          We think there might be something wrong with this link. The status for this resources IT
+          system is: {errorMsg}. Open anyways?
+        </p>
       </MyDialogContent>
       <MyDialogFooter style={{ marginTop: '0' }}>
         <ExternalLink href={resource.link} onClick={close}>

--- a/src/features/resources/ResourceItem.tsx
+++ b/src/features/resources/ResourceItem.tsx
@@ -90,7 +90,8 @@ const ResourceItem = ({
 
         if (resource.itSystem && result && result.status !== 1) {
           setItSystemError(true);
-          setErrorMsg(result.statusText);
+          // check to see if IT system has a status message
+          if (result.statusText) setErrorMsg(result.statusText);
         }
         // update date checked time
         setSystemCheckedAt(new Date());
@@ -183,10 +184,7 @@ const ResourceItem = ({
             ' on ' +
             format(systemCheckedAt)}
         </DateContainer>
-        <p>
-          We think there might be something wrong with this link. The status for this
-          resource&apos;s IT system is: {errorMsg}. Open anyways?
-        </p>
+        <p>{errorMsg}.</p>
       </MyDialogContent>
       <MyDialogFooter style={{ marginTop: '0' }}>
         <ExternalLink href={resource.link} onClick={close}>

--- a/src/features/resources/ResourceItem.tsx
+++ b/src/features/resources/ResourceItem.tsx
@@ -184,8 +184,8 @@ const ResourceItem = ({
             format(systemCheckedAt)}
         </DateContainer>
         <p>
-          We think there might be something wrong with this link. The status for this resources IT
-          system is: {errorMsg}. Open anyways?
+          We think there might be something wrong with this link. The status for this
+          resource&apos;s IT system is: {errorMsg}. Open anyways?
         </p>
       </MyDialogContent>
       <MyDialogFooter style={{ marginTop: '0' }}>


### PR DESCRIPTION

![Screen Shot 2021-04-28 at 2 02 08 PM](https://user-images.githubusercontent.com/50277029/116472116-57cbd100-a82a-11eb-9b0f-305eac7cf707.png)



should I highlight or move the system status to a new line?