### PR TITLE
disables eslint during production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "start": "EXTEND_ESLINT=true react-scripts start",
-    "build": "EXTEND_ESLINT=true react-scripts build",
+    "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "test": "TZ=UTC react-scripts test --env=jsdom",
     "test:coverage": "TZ=UTC react-scripts test --env=jsdom --coverage --watchAll=false",
     "eject": "react-scripts eject",


### PR DESCRIPTION
A new bug popped up during the build process in that react-scripts couldn't find the eslint plugin for testing-library/react.. 

https://create-react-app.dev/docs/advanced-configuration

Lint is caught pre-push and in CI so we can disable it in the build process